### PR TITLE
Fix NODE_ENV in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,12 @@ aspire-manifest.json
 __pycache__/
 
 # Private data
-appsettings.Development.json
 appsettings.Production.json
 *.bicep
+*.crt
+*.key
+*.pem
+*.csr
 
 # User-specific files
 .vscode/
@@ -34,3 +37,7 @@ _dev/
 *.userosscache
 *.sln.docstates
 *.userprefs
+
+# Misc
+.DS_Store
+.idea

--- a/infra/Aspire.AppHost/Program.cs
+++ b/infra/Aspire.AppHost/Program.cs
@@ -384,12 +384,19 @@ internal static class Program
         string directory,
         string scriptName = "start")
     {
-        return s_builder
+        var resource = s_builder
             .AddPnpmApp(name: name, workingDirectory: Path.Join(s_toolsPath, directory), scriptName: scriptName)
             .WithPnpmPackageInstallation() // use "pnpm"
             .PublishAsDockerFile()
             .WithHttpEndpoint(name: "http", env: "PORT"); // pass random port into PORT env var, used by Node.js project
         //.WithHttpEndpoint(name: "http", env: "PORT", isProxied: false); // pass random port into PORT env var, used by Node.js project
+
+        if (s_builder.ExecutionContext.IsPublishMode)
+        {
+            resource.WithEnvironment("NODE_ENV", "production");
+        }
+
+        return resource;
     }
 
     /// <summary>

--- a/infra/Aspire.AppHost/appsettings.Development.json
+++ b/infra/Aspire.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -67,6 +67,10 @@ aspire-deploy: build _aspire-deploy
 aspire-manifest:
     @{{python}} .dev/aspire-manifest.py
 
+# List files foreign to the repository, ignored by git
+git-ignored:
+    git ls-files --others --exclude-standard --ignored
+
 ###################
 #### Internals ####
 ###################


### PR DESCRIPTION
In production NODE_ENV is affected by local Aspire env, leading to Node.js being deployed with NODE_ENV == `development`.
This change forces the env to `production` during the deployment, so that cloud deployments work in production mode by default.