### PR TITLE
Check for newer images when starting docker compose up

### DIFF
--- a/infra/dev-with-aspire/Internals/AppSettings.cs
+++ b/infra/dev-with-aspire/Internals/AppSettings.cs
@@ -6,27 +6,59 @@ namespace Aspire.AppHost.Internals;
 
 public class AppSettings
 {
-    [JsonPropertyName("UseAzureAiSearch")]
-    public bool UseAzureAiSearch { get; set; } = false;
+    /// <summary>
+    /// Access key required to access the Orchestrator API.
+    /// If empty, Aspire AppHost sets a random key when deploying the Orchestrator to Azure.
+    /// </summary>
+    [JsonPropertyName("AccessKey1")]
+    public string? AccessKey1 { get; set; }
 
+    /// <summary>
+    /// Access key required to access the Orchestrator API.
+    /// If empty, Aspire AppHost sets a random key when deploying the Orchestrator to Azure.
+    /// </summary>
+    [JsonPropertyName("AccessKey2")]
+    public string? AccessKey2 { get; set; }
+
+    /// <summary>
+    /// Whether to deploy Postgres, both locally and on Azure.
+    /// </summary>
     [JsonPropertyName("UsePostgres")]
     public bool UsePostgres { get; set; } = false;
 
+    /// <summary>
+    /// Whether to deploy Postgres on Azure. UsePostgres must be true too.
+    /// </summary>
     [JsonPropertyName("UsePostgresOnAzure")]
     public bool UsePostgresOnAzure { get; set; } = false;
 
+    /// <summary>
+    /// Whether to deploy Qdrant, both locally and on Azure.
+    /// </summary>
     [JsonPropertyName("UseQdrant")]
     public bool UseQdrant { get; set; } = false;
 
+    /// <summary>
+    /// Whether to deploy Redis, both locally and on Azure.
+    /// </summary>
     [JsonPropertyName("UseRedis")]
     public bool UseRedis { get; set; } = false;
 
+    /// <summary>
+    /// Whether to deploy Redis tools (local only).
+    /// </summary>
     [JsonPropertyName("UseRedisTools")]
     public bool UseRedisTools { get; set; } = false;
 
+    /// <summary>
+    /// The Docker image to use for Postgres + pgvector.
+    /// </summary>
     [JsonPropertyName("PostgresContainerImage")]
-    public string PostgresContainerImage { get; set; } = string.Empty;
+    public string PostgresContainerImage { get; set; } = "pgvector/pgvector";
 
+    /// <summary>
+    /// Tag for the Docker image to use for Postgres + pgvector.
+    /// </summary>
     [JsonPropertyName("PostgresContainerImageTag")]
-    public string PostgresContainerImageTag { get; set; } = string.Empty;
+    public string PostgresContainerImageTag { get; set; } = "pg17";
 }

--- a/infra/dev-with-aspire/Internals/Utils.cs
+++ b/infra/dev-with-aspire/Internals/Utils.cs
@@ -16,9 +16,9 @@ internal static class Utils
             throw new ArgumentOutOfRangeException(nameof(length), "Length must be between 8 and 255.");
         }
 
-        if (charSetLength is 0 or > 256)
+        if (charSetLength is < 20 or > 256)
         {
-            throw new ArgumentException("AllowedChars.Length must be between 1 and 256.");
+            throw new ArgumentException("AllowedChars.Length must be between 20 and 256.");
         }
 
         int maxRandom = 256 - (256 % charSetLength);

--- a/infra/dev-with-aspire/Program.cs
+++ b/infra/dev-with-aspire/Program.cs
@@ -110,12 +110,16 @@ internal static class Program
             orchestrator.WithReference(redis).WaitFor(redis);
         }
 
-        // Force authentication when running on Azure, overriding appsettings.json
+        // Force authentication when running on Azure, overriding Orchestrator's appsettings.json
+        // Keys can be set in the AppHost appsettings.json file, or randomly generated.
         if (s_builder.ExecutionContext.IsPublishMode)
         {
             orchestrator.WithEnvironment("App__Authorization__Type", "AccessKey");
-            orchestrator.WithEnvironment("App__Authorization__AccessKey1", Utils.GenerateSecret(24));
-            orchestrator.WithEnvironment("App__Authorization__AccessKey2", Utils.GenerateSecret(24));
+
+            var key1 = string.IsNullOrWhiteSpace(s_config.AccessKey1) ? Utils.GenerateSecret(24) : s_config.AccessKey1;
+            var key2 = string.IsNullOrWhiteSpace(s_config.AccessKey2) ? Utils.GenerateSecret(24) : s_config.AccessKey2;
+            orchestrator.WithEnvironment("App__Authorization__AccessKey1", key1);
+            orchestrator.WithEnvironment("App__Authorization__AccessKey2", key2);
         }
 
         return orchestrator;

--- a/infra/dev-with-aspire/appsettings.Development.json
+++ b/infra/dev-with-aspire/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "App": {
+    "AccessKey1": "",
+    "AccessKey2": ""
   }
 }

--- a/infra/dev-with-aspire/appsettings.json
+++ b/infra/dev-with-aspire/appsettings.json
@@ -24,7 +24,21 @@
     "aisearchstorage": ""
   },
   "App": {
-    "UseAzureAiSearch": true,
+    /*
+     AccessKey1 & AccessKey2: if set, this key can be used to access the orchestrator API when deployed to Azure.
+                              If empty, a random key is generatoed during the deployment. Leave the value empty
+                              here, and set it in appsettings.Development.json.
+
+     UsePostgres: whether to deploy Postgres, both locally and on Azure.
+     UsePostgresOnAzure: whether to deploy Postgres on Azure. UsePostgres must be true too.
+     UseQdrant: whether to deploy Qdrant, both locally and on Azure.
+     UseRedis: whether to deploy Redis, both locally and on Azure.
+     UseRedisTools: whether to deploy Redis tools (local only).
+
+     PostgresContainerImage & PostgresContainerImageTag: the Docker image to use for Postgres + pgvector.
+    */
+    "AccessKey1": null,
+    "AccessKey2": null,
     "UsePostgres": true,
     "UsePostgresOnAzure": true,
     "UseQdrant": true,

--- a/infra/dev-with-docker/justfile
+++ b/infra/dev-with-docker/justfile
@@ -11,7 +11,7 @@ ps:
 
 # Start all services
 start:
-    @docker compose up -d
+    @docker compose up --detach --pull always
 
 # Stop all services
 stop:

--- a/infra/rag-qdrant/justfile
+++ b/infra/rag-qdrant/justfile
@@ -8,7 +8,7 @@ ps:
 
 # Start all services
 start:
-    @docker compose up -d
+    @docker compose up --detach --pull always
 
 # Stop all services
 stop:

--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ dev:
 
 # Start all the projects from source code using Aspire
 start:
-    @cd infra/dev-with-docker && docker compose up
+    @cd infra/dev-with-docker && docker compose up --pull always
 
 # Remove temporary files, build artifacts, and caches
 clean:


### PR DESCRIPTION
- Check for newer docker images when starting docker compose up (when using `just`)
- Allow to set API keys rather than random values.